### PR TITLE
Set test ID when requesting consent information

### DIFF
--- a/ios/Classes/SwiftFlutterFundingChoicesPlugin.swift
+++ b/ios/Classes/SwiftFlutterFundingChoicesPlugin.swift
@@ -16,7 +16,9 @@ public class SwiftFlutterFundingChoicesPlugin: NSObject, FlutterPlugin {
         let arguments: [String: Any?] = call.arguments as! [String: Any?]
         switch call.method {
         case "requestConsentInformation":
-            requestConsentInformation(tagForUnderAgeOfConsent: arguments["tagForUnderAgeOfConsent"] as! Bool, result: result)
+            requestConsentInformation(tagForUnderAgeOfConsent: arguments["tagForUnderAgeOfConsent"] as! Bool, 
+            testDeviceId: arguments["testDeviceId"] as! String,
+            result: result)
         case "showConsentForm": showConsentForm(result: result)
         case "reset":
             UMPConsentInformation.sharedInstance.reset()
@@ -27,9 +29,14 @@ public class SwiftFlutterFundingChoicesPlugin: NSObject, FlutterPlugin {
     }
 
     /// Requests the consent information.
-    private func requestConsentInformation(tagForUnderAgeOfConsent: Bool, result: @escaping FlutterResult) {
+    private func requestConsentInformation(tagForUnderAgeOfConsent: Bool, testDeviceId: String, result: @escaping FlutterResult) {
         let params = UMPRequestParameters()
         params.tagForUnderAgeOfConsent = tagForUnderAgeOfConsent
+
+        let debugSettings = UMPDebugSettings()
+        debugSettings.testDeviceIdentifiers = [testDeviceId]
+        debugSettings.geography = UMPDebugGeographyEEA
+        parameters.debugSettings = debugSettings
 
         UMPConsentInformation.sharedInstance.requestConsentInfoUpdate(with: params) { error in
             if error == nil {

--- a/lib/flutter_funding_choices.dart
+++ b/lib/flutter_funding_choices.dart
@@ -10,11 +10,19 @@ class FlutterFundingChoices {
       const MethodChannel('flutter_funding_choices');
 
   /// Allows to get the current consent information.
+  ///
+  /// [testDeviceId] Device id to use when testing in order to force geography to the EEA
   static Future<ConsentInformation> requestConsentInformation(
-      {bool tagForUnderAgeOfConsent = false}) async {
-    Map<String, dynamic> result = Map<String, dynamic>.from(await _channel
-        .invokeMethod('requestConsentInformation',
-            {'tagForUnderAgeOfConsent': tagForUnderAgeOfConsent}));
+      {bool tagForUnderAgeOfConsent = false, String testDeviceId = ""}) async {
+    Map<String, dynamic> result = Map<String, dynamic>.from(
+      await _channel.invokeMethod(
+        'requestConsentInformation',
+        {
+          'tagForUnderAgeOfConsent': tagForUnderAgeOfConsent,
+          'testDeviceId': testDeviceId
+        },
+      ),
+    );
     return ConsentInformation(
       consentStatus: result['consentStatus'],
       consentType: result['consentType'],


### PR DESCRIPTION
By setting the testDeviceId when calling requestConsentInformation users outside of the EEA will be able to get a consent form. Currently this only works on Android, since I don't have access to a Mac currently and can't verify that I did everything properly, however, you can view the iOS changes I made here:
https://github.com/TNorbury/FlutterFundingChoices/commit/ee625f1779714e6334bd6214e100cd4c14454c3a
If those look good I can merge them into this PR