### PR TITLE
fix iOS build and runtime crash

### DIFF
--- a/ios/Classes/SwiftFlutterFundingChoicesPlugin.swift
+++ b/ios/Classes/SwiftFlutterFundingChoicesPlugin.swift
@@ -13,10 +13,11 @@ public class SwiftFlutterFundingChoicesPlugin: NSObject, FlutterPlugin {
     }
 
     public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
-        let arguments: [String: Any?] = call.arguments as! [String: Any?]
+        let arguments: [String: Any?] = call.arguments as? [String: Any?] ?? ["": ""]
         switch call.method {
         case "requestConsentInformation":
-            requestConsentInformation(tagForUnderAgeOfConsent: arguments["tagForUnderAgeOfConsent"] as! Bool, testDevicesHashedIds: arguments["testDevicesHashedIds"] as! String, result: result)
+            requestConsentInformation(tagForUnderAgeOfConsent: arguments["tagForUnderAgeOfConsent"] as! Bool,
+                testDevicesHashedIds: arguments["testDevicesHashedIds"] as! [String], result: result)
         case "showConsentForm": showConsentForm(result: result)
         case "reset":
             UMPConsentInformation.sharedInstance.reset()
@@ -31,11 +32,13 @@ public class SwiftFlutterFundingChoicesPlugin: NSObject, FlutterPlugin {
         let params = UMPRequestParameters()
         params.tagForUnderAgeOfConsent = tagForUnderAgeOfConsent
 
-        let debugSettings = UMPDebugSettings()
-        debugSettings.testDeviceIdentifiers = testDevicesHashedIds
-        debugSettings.geography = UMPDebugGeographyEEA
-        parameters.debugSettings = debugSettings
-
+        if (testDevicesHashedIds.count > 0) {
+            let debugSettings = UMPDebugSettings()
+            debugSettings.testDeviceIdentifiers = testDevicesHashedIds
+            debugSettings.geography = UMPDebugGeography.EEA
+            params.debugSettings = debugSettings
+        }
+        
         UMPConsentInformation.sharedInstance.requestConsentInfoUpdate(with: params) { error in
             if error == nil {
                 var consentInfo: [String: Any] = [:]


### PR DESCRIPTION
the code I added for the iOS testing thing was causing build errors, so I fixed that.

The casting of call.arguments was causing a runtime crash when showConsentForm was being called (I think because there are no arguments for that method), so I made it default to an empty map if the cast returned null.

Changes have been tested on an iOS device.